### PR TITLE
set cookie expire to match token exire date & reset cookie on logout

### DIFF
--- a/src/Handler/LogoutHandler.php
+++ b/src/Handler/LogoutHandler.php
@@ -12,6 +12,7 @@ use ConnectHolland\SecureJWTBundle\Message\Logout;
 use Doctrine\Common\Persistence\ManagerRegistry;
 use Doctrine\ORM\EntityManager;
 use Lexik\Bundle\JWTAuthenticationBundle\Security\Authentication\Token\JWTUserToken;
+use Symfony\Component\HttpFoundation\Response;
 use Symfony\Component\Messenger\Handler\MessageHandlerInterface;
 use Symfony\Component\Security\Core\Authentication\Token\Storage\TokenStorageInterface;
 
@@ -30,9 +31,10 @@ class LogoutHandler implements MessageHandlerInterface
     /**
      * Invalidate the current login by invalidating the current JWT token.
      */
-    public function __invoke(Logout $logout): void
+    public function __invoke(Logout $logout): Response
     {
         $token = $this->tokenStorage->getToken();
+        $response = new Response();
 
         if ($token instanceof JWTUserToken) {
             $invalidToken = new InvalidToken();
@@ -46,6 +48,11 @@ class LogoutHandler implements MessageHandlerInterface
             } else {
                 throw new \RuntimeException('Unable to invalid token because doctrine is not set up correctly. Please configure `vendor/connectholland/secure-jwt/src/Entity` as an annotated entity path (see README.md for more details)');
             }
+
+            $response->headers->clearCookie('BEARER', '/', null, true, true, 'none');
+
         }
+
+        return $response;
     }
 }

--- a/src/Security/Http/Authentication/AuthenticationSuccessHandler.php
+++ b/src/Security/Http/Authentication/AuthenticationSuccessHandler.php
@@ -45,7 +45,7 @@ class AuthenticationSuccessHandler implements AuthenticationSuccessHandlerInterf
         $decoded               = $this->jwtEncoder->decode($data['token']);
         $this->responsePayload = array_merge($this->responsePayload, $decoded);
         $response              = new JsonResponse(['result' => 'ok', 'payload' => $this->responsePayload]);
-        $response->headers->setCookie(new Cookie('BEARER', $data['token'], 0, '/', null, true, true, false, $this->sameSite));
+        $response->headers->setCookie(new Cookie('BEARER', $data['token'], $decoded['exp'], '/', null, true, true, false, $this->sameSite));
 
         return  $response;
     }

--- a/tests/Security/Http/Authentication/AuthenticationSuccessHandlerTest.php
+++ b/tests/Security/Http/Authentication/AuthenticationSuccessHandlerTest.php
@@ -45,6 +45,7 @@ class AuthenticationSuccessHandlerTest extends TestCase
         $this->assertSame('example@example.org', $content['payload']['user']);
         $this->assertCount(1, $cookies);
         $this->assertSame('secrettoken', $cookies[0]->getValue());
+        $this->assertSame(1627902433, $cookies[0]->getExpiresTime());
     }
 
     public function testHandleAuthenticationSuccess()
@@ -94,7 +95,7 @@ class AuthenticationSuccessHandlerTest extends TestCase
         $encoder
             ->expects($this->once())
             ->method('decode')
-            ->willReturn(['user' => 'example@example.org']);
+            ->willReturn(['user' => 'example@example.org', 'exp' => 1627902433]);
 
         return $encoder;
     }


### PR DESCRIPTION
Expire date now matches the expire date from the BEARER token.